### PR TITLE
Adds Blog post about RenderDoc

### DIFF
--- a/content/blog/2024/Development News/Introducing-RenderDoc/attach.png
+++ b/content/blog/2024/Development News/Introducing-RenderDoc/attach.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6879233a4fa644ceaceec9ddca221c1b23a3a8b94d40b743f15356999dc3272c
+size 11385

--- a/content/blog/2024/Development News/Introducing-RenderDoc/index.md
+++ b/content/blog/2024/Development News/Introducing-RenderDoc/index.md
@@ -34,7 +34,7 @@ This tool is essential for debugging complex shaders or performance issues relat
 
 ### How to Use
 
-Start vvvv with the `--debug-gpu` flag and add the **RenderDocManager** node to your patch. For more information, refer to the [documentation](#).
+Start vvvv with the `--debug-gpu` flag and add the **RenderDocManager** node to your patch. For more information, refer to the [documentation](https://thegraybook.vvvv.org/reference/libraries/3d/gpu-debugging.html).
 
 ## Credits
 

--- a/content/blog/2024/Development News/Introducing-RenderDoc/index.md
+++ b/content/blog/2024/Development News/Introducing-RenderDoc/index.md
@@ -1,0 +1,41 @@
+---
+categories: "Development News"
+author: "tebjan"
+date: "2024-10-22"
+title: "Introducing: RenderDoc GPU debugging"
+description: "Easy GPU frame debugging for VL.Stride"
+thumb: thumb.png
+---
+
+# RenderDoc for vvvv gamma
+
+[RenderDoc](https://renderdoc.org/) support has been added to [VL.Stride](https://github.com/vvvv/VL.StandardLibs/tree/main/VL.Stride) for vvvv gamma `preview 6.7-199` and later. This simplifies GPU and shader debugging, making it easier to capture and analyze GPU calls and shaders in larger projects.
+
+## Key Features
+
+![](renderdoc.png)
+
+RenderDoc enables inspection of the graphics pipeline for captured frames. It features texture, buffer and mesh views per draw call and even allows line-by-line shader debugging with value inspection.
+
+### RenderDocManager Node
+![](node.png)
+
+Integrates with RenderDoc, controlling frame capture directly in vvvv. RenderDoc can then inspect the frames for GPU debugging.
+
+![](attach.png)
+  
+### `--debug-gpu` Flag
+
+vvvv must be started with this command-line flag to enable RenderDoc’s GPU capture functionality. It enables the debug features of the graphics device and helps gather detailed GPU information.
+
+### Why Use It?
+
+This tool is essential for debugging complex shaders or performance issues related to GPU operations. It removes much of the guesswork by providing a detailed view of GPU processes. Combined with RenderDoc's powerful analysis features and the Stride Profiler, it makes troubleshooting faster and more accurate, especially in graphics-heavy projects.
+
+### How to Use
+
+Start vvvv with the `--debug-gpu` flag and add the **RenderDocManager** node to your patch. For more information, refer to the [documentation](#).
+
+## Credits
+
+Development of this was sponsored by [Studio Bruell](https://studiobruell.de/) and [Refik Anadol Studio](https://refikanadolstudio.com/).

--- a/content/blog/2024/Development News/Introducing-RenderDoc/index.md
+++ b/content/blog/2024/Development News/Introducing-RenderDoc/index.md
@@ -34,7 +34,7 @@ This tool is essential for debugging complex shaders or performance issues relat
 
 ### How to Use
 
-Start vvvv with the `--debug-gpu` flag and add the **RenderDocManager** node to your patch. For more information, refer to the [documentation](https://thegraybook.vvvv.org/reference/libraries/3d/gpu-debugging.html).
+There is a dedicated [documentation page](https://thegraybook.vvvv.org/reference/libraries/3d/gpu-debugging.html) in The Gray Book with all the details.
 
 ## Credits
 

--- a/content/blog/2024/Development News/Introducing-RenderDoc/index.md
+++ b/content/blog/2024/Development News/Introducing-RenderDoc/index.md
@@ -1,7 +1,7 @@
 ---
 categories: "Development News"
 author: "tebjan"
-date: "2024-10-22"
+date: "2024-10-23"
 title: "Introducing: RenderDoc GPU debugging"
 description: "Easy GPU frame debugging for VL.Stride"
 thumb: thumb.png

--- a/content/blog/2024/Development News/Introducing-RenderDoc/node.png
+++ b/content/blog/2024/Development News/Introducing-RenderDoc/node.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8088f7aad30eee6d0abebf89e9e129e27554cc75b6c052a5b19f95fc89b649ef
+size 8490

--- a/content/blog/2024/Development News/Introducing-RenderDoc/renderdoc.png
+++ b/content/blog/2024/Development News/Introducing-RenderDoc/renderdoc.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8b9f758962a4dc99069d29464ba110f71f13e0d701151c6b1af0cc74f81b666
+size 230017

--- a/content/blog/2024/Development News/Introducing-RenderDoc/thumb.png
+++ b/content/blog/2024/Development News/Introducing-RenderDoc/thumb.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ecf7463fbdff4c8f4975d0ca7ff25447f09f3694c5cd473d3fb6d7b767fdbc7
+size 4796


### PR DESCRIPTION
Introducing the new RenderDoc connection.

Documentation should be merged first: https://github.com/vvvv/The-Gray-Book/pull/52